### PR TITLE
Fix build when using Zig 0.11.0

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -32,7 +32,7 @@ pub fn build(b: *std.Build) void {
     // This declares intent for the library to be installed into the standard
     // location when the user invokes the "install" step (the default step when
     // running `zig build`).
-    lib.install();
+    b.installArtifact(lib);
 
     // Creates a step for unit testing.
     const main_tests = b.addTest(.{


### PR DESCRIPTION
Fix build when using Zig 0.11.0

Before:

```sh
$ zig version
0.11.0
$ zig build
/home/eric/.zvm/0.11.0/lib/std/Build/Step/Compile.zig:616:21: error: deprecated; use std.Build.installArtifact
pub const install = @compileError("deprecated; use std.Build.installArtifact");
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
referenced by:
    build: /home/eric/Documents/github/zkwargs/build.zig:35:8
    runBuild__anon_7188: /home/eric/.zvm/0.11.0/lib/std/Build.zig:1638:27
```


Spawning from wanting to use [`zshuffle`](https://github.com/hmusgrave/zshuffle) but finding that the dependency fails the build with the error above. (also need to [make the same change to `zshuffle` itself](https://github.com/hmusgrave/zshuffle/pull/1))