### PR TITLE
Use `const` since local variable is never mutated

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -166,7 +166,7 @@ const RangeOpt = struct {
 };
 
 fn range_sum(data: anytype, _kwargs: anytype) @TypeOf(data[0]) {
-    var kwargs = Options(RangeOpt).parse(_kwargs);
+    const kwargs = Options(RangeOpt).parse(_kwargs);
 
     var total: @TypeOf(data[0]) = 0;
     var i: usize = kwargs.start;
@@ -180,7 +180,7 @@ fn range_sum(data: anytype, _kwargs: anytype) @TypeOf(data[0]) {
 }
 
 test "doesn't crash" {
-    var data = [_]u8{ 0, 1, 2, 3, 4, 5 };
+    const data = [_]u8{ 0, 1, 2, 3, 4, 5 };
     try expectEqual(@as(u8, 15), range_sum(data, .{ .step = 1 }));
     try expectEqual(@as(u8, 6), range_sum(data, .{ .step = 2 }));
     try expectEqual(@as(u8, 2), range_sum(data, .{ .step = 2, .max_count = 2 }));


### PR DESCRIPTION
Use `const` since local variable is never mutated

Spotted while trying this project out with the latest Zig `master` (`0.12.0-dev.1676+40b8c993f`)

```
src/main.zig:169:9: error: local variable is never mutated
    var kwargs = Options(RangeOpt).parse(_kwargs);
        ^~~~~~
src/main.zig:169:9: note: consider using 'const'
src/main.zig:183:9: error: local variable is never mutated
    var data = [_]u8{ 0, 1, 2, 3, 4, 5 };
        ^~~~
src/main.zig:183:9: note: consider using 'const'
```